### PR TITLE
Feature: Use more default `hatch` commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,13 @@ jobs:
         run: |
           pip3 --quiet install --upgrade hatch uv
       -
-        name: Run tests
+        name: Show environment
         run: |
-          hatch test --show --python '${{ steps.py-setup.outputs.python-version }}'
+          hatch test --show --python ${{ matrix.python-version }}
       -
         name: Run tests
         run: |
-          hatch test --cover --python '${{ steps.py-setup.outputs.python-version }}'
+          hatch test --cover --python ${{ matrix.python-version }}
       -
         name: Upload coverage to Codecov
         if: matrix.python-version == '3.10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
         run: |
           pip3 --quiet install --upgrade hatch uv
       -
+        name: Show Python
+        run: |
+          hatch python show
+      -
         name: Show environment
         run: |
           hatch test --show --python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,6 @@ jobs:
           hatch --version
           uv --version
       -
-        name: Show Python
-        run: |
-          hatch python show
-      -
         name: Show environment
         run: |
           hatch test --show --python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
       -
         name: Install Hatch
         run: |
-          pip3 --quiet install --upgrade hatch
+          pip3 --quiet install --upgrade hatch uv
       -
         name: Lint project
         run: |
-          hatch run lint:all
+          hatch fmt --check
       -
         name: Check files with pre-commit
         uses: pre-commit/action@v3.0.1
@@ -67,21 +67,22 @@ jobs:
       -
         name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
+        id: py-setup
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
       -
         name: Install Hatch
         run: |
-          pip3 --quiet install --upgrade hatch
-      -
-        name: List installed dependencies
-        run: |
-          hatch run pip-list
+          pip3 --quiet install --upgrade hatch uv
       -
         name: Run tests
         run: |
-          hatch run cov
+          hatch test --show --python '${{ steps.py-setup.outputs.python-version }}'
+      -
+        name: Run tests
+        run: |
+          hatch test --cover --python '${{ steps.py-setup.outputs.python-version }}'
       -
         name: Upload coverage to Codecov
         if: matrix.python-version == '3.10'
@@ -115,7 +116,7 @@ jobs:
       -
         name: Install Hatch
         run: |
-          pip3 --quiet install --upgrade hatch
+          pip3 --quiet install --upgrade hatch uv
       -
         name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         name: Install Hatch
         run: |
           pip3 --quiet install --upgrade hatch uv
+          hatch --version
+          uv --version
       -
         name: Lint project
         run: |
@@ -75,6 +77,8 @@ jobs:
         name: Install Hatch
         run: |
           pip3 --quiet install --upgrade hatch uv
+          hatch --version
+          uv --version
       -
         name: Show Python
         run: |
@@ -87,6 +91,7 @@ jobs:
         name: Run tests
         run: |
           hatch test --cover --python ${{ matrix.python-version }}
+          ls -ahl .
       -
         name: Upload coverage to Codecov
         if: matrix.python-version == '3.10'
@@ -121,6 +126,8 @@ jobs:
         name: Install Hatch
         run: |
           pip3 --quiet install --upgrade hatch uv
+          hatch --version
+          uv --version
       -
         name: Build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -75,26 +75,7 @@ virtualenv
 /docker-compose.env
 /docker-compose.yml
 .ruff_cache/
-
-# Used for development
-scripts/import-for-development
-scripts/nuke
-
-# Static files collected by the collectstatic command
-/static/
-
-# Stored PDFs
-/media/
-/data/
-/paperless.conf
-/consume/
-/export/
-
-# this is where the compiled frontend is moved to.
-/src/documents/static/frontend/
+.mypy_cache/
 
 # mac os
 .DS_Store
-
-# celery schedule file
-celerybeat-schedule*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 repos:
   # General hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-docstring-first
       - id: check-json
@@ -37,10 +37,9 @@ repos:
         exclude: "(^Pipfile\\.lock$)"
   # Python hooks
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.3.0'
+    rev: 'v0.4.2'
     hooks:
+      # Run the linter.
       - id: ruff
-  - repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-      - id: black
+      # Run the formatter.
+      - id: ruff-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated development tools
-- Bump pypa/gh-action-pypi-publish from 1.8.12 to 1.8.14 (by @dependabot in #16)
+- Bump pypa/gh-action-pypi-publish from 1.8.12 to 1.8.14 (by [@dependabot](https://github.com/apps/dependabot) in [#16](https://github.com/stumpylog/tika-client/pull/16))
+- Update development to use `hatch test` and `hatch fmt` ([#17](https://github.com/stumpylog/tika-client/pull/17))
 
 ## [0.5.0] - 2023-11-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ cov = [
 pip-list = "pip list"
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9", "pypy3.10"]
 
 [tool.hatch.envs.hatch-static-analysis]
 # https://hatch.pypa.io/latest/config/internal/static-analysis/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,9 +91,15 @@ config-path = "none"
 # https://hatch.pypa.io/latest/config/internal/testing/
 parallel = true
 randomize = true
-
 dependencies = [
+  "coverage-enable-subprocess == 1.0",
+  "coverage[toml] ~= 7.4",
   "pytest < 8.0; python_version < '3.9'",
+  "pytest ~= 8.1; python_version >= '3.9'",
+  "pytest-mock ~= 3.12",
+  "pytest-randomly ~= 3.15",
+  "pytest-rerunfailures ~= 14.0",
+  "pytest-xdist[psutil] ~= 3.5",
 ]
 extra-dependencies = [
   "pytest-sugar",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+#
+# Project Configuration
+#
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -32,7 +35,8 @@ classifiers = [
 ]
 dependencies = [
   "httpx ~= 0.27; python_version >= '3.9'",
-  "httpx ~= 0.24; python_version < '3.9'"
+  "httpx ~= 0.24; python_version < '3.9'",
+  "typing-extensions; python_version < '3.11'"
 ]
 
 [project.urls]
@@ -40,6 +44,9 @@ Documentation = "https://github.com/stumpylog/tika-rest-client#readme"
 Issues = "https://github.com/stumpylog/tika-rest-client/issues"
 Source = "https://github.com/stumpylog/tika-rest-client"
 
+#
+# Hatch Configuration
+#
 [tool.hatch.version]
 path = "src/tika_client/__about__.py"
 
@@ -50,16 +57,7 @@ exclude = [
 ]
 
 [tool.hatch.envs.default]
-dependencies = [
-  "coverage[toml] ~= 7.4.0",
-  "pytest >= 7.4",
-  "pytest-sugar",
-  "pytest-cov",
-  "pytest-xdist",
-  "pytest-httpx ~= 0.30; python_version >= '3.9'",
-  "pytest-httpx ~= 0.22; python_version < '3.9'",
-  "python-magic",
-]
+installer = "uv"
 
 [tool.hatch.envs.default.scripts]
 version = "python3 --version"
@@ -84,39 +82,53 @@ pip-list = "pip list"
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]
 
-[tool.hatch.envs.lint]
+[tool.hatch.envs.hatch-static-analysis]
+# https://hatch.pypa.io/latest/config/internal/static-analysis/
+dependencies = ["ruff ~= 0.4.2"]
+config-path = "none"
+
+[tool.hatch.envs.hatch-test]
+# https://hatch.pypa.io/latest/config/internal/testing/
+parallel = true
+randomize = true
+extra-dependencies = [
+  "pytest-sugar",
+  "pytest-httpx ~= 0.30; python_version >= '3.9'",
+  "pytest-httpx ~= 0.22; python_version < '3.9'",
+  "python-magic",
+]
+extra-args = ["--maxprocesses=16"]
+
+#
+# Custom Environments
+#
+[tool.hatch.envs.typing]
 detached = true
 dependencies = [
-  "black ~= 24.2.0",
-  "mypy ~= 1.8.0",
-  "ruff ~= 0.3.0",
+  "mypy ~= 1.10.0",
   "httpx",
 ]
 
-[tool.hatch.envs.lint.scripts]
-typing = [
+[tool.hatch.envs.typing.scripts]
+run = [
   "mypy --version",
   "mypy --install-types --non-interactive {args:src/tika_client}"
 ]
-style = [
-  "ruff check {args:.}",
-  "black --check --diff {args:.}",
-]
-fmt = [
-  "black {args:.}",
-  "ruff check --fix {args:.}",
-  "style",
-]
-all = [
-  "pip list",
-  "style",
-  "typing",
+
+[tool.hatch.envs.pre-commit]
+template = "pre-commit"
+detached = true
+dependencies = [
+  "pre-commit ~= 3.7.0",
 ]
 
-[tool.black]
-target-version = ["py38"]
-line-length = 120
+[tool.hatch.envs.pre-commit.scripts]
+check = ["pre-commit run --all-files"]
+update = ["pre-commit autoupdate"]
 
+#
+# Tool Configuration
+#
 [tool.ruff]
 # https://docs.astral.sh/ruff/settings/
 fix = true
@@ -139,6 +151,7 @@ extend-select = [
   "ERA",
   "EXE",
   "F",
+  "FA",
   "FBT",
   "FLY",
   "I",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,29 +59,6 @@ exclude = [
 [tool.hatch.envs.default]
 installer = "uv"
 
-[tool.hatch.envs.default.scripts]
-version = "python3 --version"
-test = "pytest {args:tests}"
-cov-clear = "coverage erase"
-test-cov = "coverage run -m pytest {args:tests}"
-cov-report = [
-  "- coverage combine",
-  "coverage report",
-]
-cov-html = "coverage html"
-cov-json = "coverage json"
-cov = [
-  "version",
-  "cov-clear",
-  "test-cov",
-  "cov-report",
-  "cov-json"
-]
-pip-list = "pip list"
-
-[[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9", "pypy3.10"]
-
 [tool.hatch.envs.hatch-static-analysis]
 # https://hatch.pypa.io/latest/config/internal/static-analysis/
 dependencies = ["ruff ~= 0.4.2"]
@@ -103,12 +80,31 @@ dependencies = [
 ]
 extra-dependencies = [
   "pytest-sugar",
-  "pytest-cov",
   "pytest-httpx ~= 0.30; python_version >= '3.9'",
   "pytest-httpx ~= 0.22; python_version < '3.9'",
   "python-magic",
 ]
-extra-args = ["--maxprocesses=16", "--cov-report=json"]
+extra-args = ["--maxprocesses=8"]
+
+[tool.hatch.envs.hatch-test.scripts]
+run = [
+  "python3 --version",
+  "pytest{env:HATCH_TEST_ARGS:} {args}"]
+
+run-cov = [
+  "python3 --version",
+  "coverage erase",
+  "coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}"
+]
+cov-combine = ["coverage combine"]
+cov-report = [
+  "coverage report",
+  "coverage json",
+  "coverage html"
+]
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9", "pypy3.10"]
 
 #
 # Custom Environments
@@ -256,3 +252,6 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true
 warn_unused_configs = true
+
+[tool.pytest.ini_options]
+minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ config-path = "none"
 parallel = true
 randomize = true
 extra-dependencies = [
+  "pytest < 8.0; python_version < '3.9'",
   "pytest-sugar",
   "pytest-httpx ~= 0.30; python_version >= '3.9'",
   "pytest-httpx ~= 0.22; python_version < '3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,11 @@ config-path = "none"
 # https://hatch.pypa.io/latest/config/internal/testing/
 parallel = true
 randomize = true
-extra-dependencies = [
+
+dependencies = [
   "pytest < 8.0; python_version < '3.9'",
+]
+extra-dependencies = [
   "pytest-sugar",
   "pytest-httpx ~= 0.30; python_version >= '3.9'",
   "pytest-httpx ~= 0.22; python_version < '3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ cov-report = [
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9", "pypy3.10"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
 
 #
 # Custom Environments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,12 @@ dependencies = [
 ]
 extra-dependencies = [
   "pytest-sugar",
+  "pytest-cov",
   "pytest-httpx ~= 0.30; python_version >= '3.9'",
   "pytest-httpx ~= 0.22; python_version < '3.9'",
   "python-magic",
 ]
-extra-args = ["--maxprocesses=16"]
+extra-args = ["--maxprocesses=16", "--cov-report=json"]
 
 #
 # Custom Environments

--- a/src/tika_client/_resource_recursive.py
+++ b/src/tika_client/_resource_recursive.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Final
-from typing import List
 
-from httpx import Client
-
-from tika_client._types import MimeType
 from tika_client._utils import BaseResource
-from tika_client.data_models import TikaResponse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import Client
+
+    from tika_client._types import MimeType
+    from tika_client.data_models import TikaResponse
 
 logger = logging.getLogger("tika-client.rmeta")
 
@@ -18,7 +23,7 @@ class _TikaRmetaBase(BaseResource):
         endpoint: str,
         filepath: Path,
         mime_type: MimeType = None,
-    ) -> List[TikaResponse]:
+    ) -> list[TikaResponse]:
         """
         Given a specific endpoint and a file, do a multipart put to the endpoint
         """

--- a/src/tika_client/_types.py
+++ b/src/tika_client/_types.py
@@ -1,6 +1,12 @@
-from typing import Optional
-from typing import Union
+from __future__ import annotations
 
-MimeType = Optional[str]
+import sys
 
-RequestContent = Union[str, bytes]
+if sys.version_info >= (3, 11):  # pragma: no cover
+    from typing import Self
+else:  # pragma: no cover
+    from typing_extensions import Self  # noqa: F401
+
+MimeType = str | None
+
+RequestContent = str | bytes

--- a/src/tika_client/_types.py
+++ b/src/tika_client/_types.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import sys
+from typing import Optional
+from typing import Union
 
 if sys.version_info >= (3, 11):  # pragma: no cover
     from typing import Self
 else:  # pragma: no cover
     from typing_extensions import Self  # noqa: F401
 
-MimeType = str | None
+MimeType = Optional[str]
 
-RequestContent = str | bytes
+RequestContent = Union[str, bytes]

--- a/src/tika_client/_utils.py
+++ b/src/tika_client/_utils.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import logging
 import urllib.parse
-from pathlib import Path
-from typing import Dict
-
-from httpx import Client
+from typing import TYPE_CHECKING
 
 from tika_client._constants import MIN_COMPRESS_LEN
-from tika_client._types import MimeType
-from tika_client._types import RequestContent
 from tika_client.data_models import TikaResponse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import Client
+
+    from tika_client._types import MimeType
+    from tika_client._types import RequestContent
 
 logger = logging.getLogger("tika-client.utils")
 
@@ -18,7 +23,12 @@ class BaseResource:
         self.client = client
         self.compress = compress
 
-    def _put_multipart(self, endpoint: str, filepath: Path, mime_type: MimeType = None) -> Dict:
+    def _put_multipart(
+        self,
+        endpoint: str,
+        filepath: Path,
+        mime_type: MimeType = None,
+    ) -> dict:
         """
         Given an endpoint, file and an optional mime type, does a multi-part form
         data upload of the file to the end point.
@@ -33,7 +43,9 @@ class BaseResource:
             try:
                 # Filename is valid ASCII, use it
                 filepath.name.encode("ascii")
-                content_header = {"Content-Disposition": f"attachment; filename={filepath.name}"}
+                content_header = {
+                    "Content-Disposition": f"attachment; filename={filepath.name}",
+                }
             except UnicodeEncodeError:
                 # Ignore non-ascii, in case RFC 5987 is not supported, but also encode it
                 filename_safed = filepath.name.encode("ascii", "ignore").decode("ascii")
@@ -47,7 +59,12 @@ class BaseResource:
             # Always JSON
             return resp.json()
 
-    def _put_content(self, endpoint: str, content: RequestContent, mime_type: MimeType = None) -> Dict:
+    def _put_content(
+        self,
+        endpoint: str,
+        content: RequestContent,
+        mime_type: MimeType = None,
+    ) -> dict:
         """
         Give, an endpoint, content and optional mime type, does an HTTP PUT with the given content.
 
@@ -72,7 +89,7 @@ class BaseResource:
         return resp.json()
 
     @staticmethod
-    def _decoded_response(resp_json: Dict):
+    def _decoded_response(resp_json: dict):
         """
         If possible, returns a more detailed class with properties that appear often in this
         mime type.  Otherwise, it's a basically raw data response, but with some helpers

--- a/src/tika_client/client.py
+++ b/src/tika_client/client.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import logging
-from types import TracebackType
-from typing import Dict
-from typing import Optional
-from typing import Type
+from typing import TYPE_CHECKING
 
 from httpx import Client
 
 from tika_client._resource_meta import Metadata
 from tika_client._resource_recursive import Recursive
 from tika_client._resource_tika import Tika
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from tika_client._types import Self
 
 
 class TikaClient:
@@ -38,19 +42,19 @@ class TikaClient:
         self.tika = Tika(self._client, compress=compress)
         self.rmeta = Recursive(self._client, compress=compress)
 
-    def add_headers(self, header: Dict[str, str]) -> None:  # pragma: no cover
+    def add_headers(self, header: dict[str, str]) -> None:  # pragma: no cover
         """
         Updates the httpx Client headers with the given values
         """
         self._client.headers.update(header)
 
-    def __enter__(self) -> "TikaClient":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         self._client.close()

--- a/src/tika_client/data_models.py
+++ b/src/tika_client/data_models.py
@@ -1,13 +1,11 @@
+from __future__ import annotations
+
 import logging
 import re
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from enum import Enum
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
 
 # Based on https://cwiki.apache.org/confluence/display/TIKA/Metadata+Overview
 
@@ -72,11 +70,11 @@ class TikaResponse:
     All returned data is available in the decoded JSON form under the .data attribute
     """
 
-    def __init__(self, data: Dict) -> None:
+    def __init__(self, data: dict) -> None:
         self.data = data
         # Always set keys
         self.type: str = self.data[TikaKey.ContentType]
-        self.parsers: List[str] = self.data[TikaKey.Parsers]
+        self.parsers: list[str] = self.data[TikaKey.Parsers]
 
         # Tika keys
         self.content = self.get_optional_string(TikaKey.Content)
@@ -99,12 +97,18 @@ class TikaResponse:
 
     # Helpers
 
-    def get_optional_int(self, key: Union[TikaKey, DublinCoreKey, XmpKey, str]) -> Optional[int]:
+    def get_optional_int(
+        self,
+        key: TikaKey | DublinCoreKey | XmpKey | str,
+    ) -> int | None:
         if key not in self.data:  # pragma: no cover
             return None
         return int(self.data[key])
 
-    def get_optional_datetime(self, key: Union[TikaKey, DublinCoreKey, XmpKey, str]) -> Optional[datetime]:
+    def get_optional_datetime(
+        self,
+        key: TikaKey | DublinCoreKey | XmpKey | str,
+    ) -> datetime | None:
         """
         If present, attempts to parse the given key as an ISO-8061 format
         datetime, including timezone handling and return if.
@@ -145,7 +149,10 @@ class TikaResponse:
             tzinfo=tzinfo,
         )
 
-    def get_optional_string(self, key: Union[TikaKey, DublinCoreKey, XmpKey, str]) -> Optional[str]:
+    def get_optional_string(
+        self,
+        key: TikaKey | DublinCoreKey | XmpKey | str,
+    ) -> str | None:
         if key not in self.data:
             return None
         return self.data[key]

--- a/tests/test_datetime_formats.py
+++ b/tests/test_datetime_formats.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from datetime import timezone
 
 import magic
+import pytest
 from pytest_httpx import HTTPXMock
 
 from tests.conftest import SAMPLE_DIR
@@ -68,14 +69,9 @@ class TestDateTimeFormat:
 
         resp = tika_client.metadata.from_file(test_file, magic.from_file(str(test_file), mime=True))
 
-        assert resp.created == datetime(
-            year=2023,
-            month=6,
-            day=17,
-            hour=16,
-            minute=30,
-            second=44,
-            tzinfo=timezone(timedelta(hours=8)),
+        assert resp.created == pytest.approx(
+            datetime(year=2023, month=6, day=17, hour=16, minute=30, second=44, tzinfo=timezone(timedelta(hours=8))),
+            rel=timedelta(seconds=1),
         )
 
     def test_parse_offset_date_format_negative(self, tika_client: TikaClient, httpx_mock: HTTPXMock):
@@ -90,14 +86,17 @@ class TestDateTimeFormat:
 
         resp = tika_client.metadata.from_file(test_file, magic.from_file(str(test_file), mime=True))
 
-        assert resp.created == datetime(
-            year=2023,
-            month=6,
-            day=17,
-            hour=16,
-            minute=30,
-            second=44,
-            tzinfo=timezone(timedelta(hours=-8)),
+        assert resp.created == pytest.approx(
+            datetime(
+                year=2023,
+                month=6,
+                day=17,
+                hour=16,
+                minute=30,
+                second=44,
+                tzinfo=timezone(timedelta(hours=-8)),
+            ),
+            rel=timedelta(seconds=1),
         )
 
     def test_parse_offset_date_format_python_isoformat(self, tika_client: TikaClient, httpx_mock: HTTPXMock):
@@ -114,7 +113,7 @@ class TestDateTimeFormat:
 
         resp = tika_client.metadata.from_file(test_file, magic.from_file(str(test_file), mime=True))
 
-        assert resp.created == expected
+        assert resp.created == pytest.approx(expected, rel=timedelta(seconds=1))
 
     def test_parse_offset_date_no_match(self, tika_client: TikaClient, httpx_mock: HTTPXMock):
         """


### PR DESCRIPTION
Use the default hatch commands for:

- Formatting: `hatch fmt`
  - This includes transitioning from `black` to `ruff format`
- Testing via `hatch test`
- Installation via `uv`