### PR TITLE
fix: typo in code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pypa/gh-action-pypi-publish` updated to v1.8.10
 - CI testing now uses the official Apache Tika image (minimal) instead of the paperless-ngx image
 
+### Fixed
+
+- Typo in README codeblock by @Chaostheorie ([#19](https://github.com/stumpylog/tika-client/pull/19))
+
 ## [0.4.0] - 2023-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ from tika_client import TikaClient
 test_file = Path("sample.docx")
 
 
-with TikaClient("http://localhost:9998) as client
+with TikaClient("http://localhost:9998") as client
 
     # Extract a document's metadata
     metadata = client.metadata.from_file(test_file)


### PR DESCRIPTION
Minor typo with missing `"` in code block. Noticed it when trying to copy the snippet into a script.