### PR TITLE
Breaking: httpx is now an optional extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Change
+
+- `httpx` is no longer installed by default. Install at least one backend via an extra:
+  `pip install "tika-client[httpx]"`, `pip install "tika-client[niquests]"`, or
+  `pip install "tika-client[requests]"`. The default `backend="auto"` on `TikaClient`
+  and `AsyncTikaClient` discovers whichever backend is present at runtime.
+
 ### Added
 
 - Pluggable HTTP backend system, decoupling the client from any single HTTP library
+- `httpx` as an optional HTTP backend (`pip install tika-client[httpx]`)
 - `niquests` as an optional HTTP backend supporting both sync and async (`pip install tika-client[niquests]`)
 - `requests` as an optional sync-only HTTP backend (`pip install tika-client[requests]`)
 - `backend` parameter on `TikaClient` and `AsyncTikaClient` accepting `"httpx"`, `"niquests"`, `"requests"`, or `"auto"` (default); `"auto"` tries each in order

--- a/README.md
+++ b/README.md
@@ -32,13 +32,17 @@ A simple, fully-typed Python client for extracting text, HTML, and metadata from
 
 ## Installation
 
-`httpx` is included as a regular dependency. Two optional extras provide alternative backends:
+No HTTP backend is installed by default. Install `tika-client` with one of the three backend extras:
 
 ```console
-pip install tika-client
+pip install "tika-client[httpx]"
 pip install "tika-client[niquests]"
 pip install "tika-client[requests]"
 ```
+
+All three extras can be combined. The default `backend="auto"` discovers whichever backend is present
+at runtime, trying `httpx` first, then `niquests`, then `requests`. A bare `pip install tika-client`
+with no extras will raise `ImportError` on first use.
 
 ## Usage
 
@@ -219,8 +223,8 @@ with TikaClient("http://localhost:9998") as client:
 
 ## HTTP Backend Selection
 
-By default, `tika-client` uses `httpx`. You can select a different backend explicitly or let the
-library auto-detect one:
+No backend is installed by default. Install at least one extra and select it explicitly, or let
+`"auto"` (the default) detect whichever is present (tries `httpx`, then `niquests`, then `requests`):
 
 ```python
 from tika_client import TikaClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,13 +52,13 @@ dynamic = [ "version" ]
 #
 dependencies = [
   "anyio>=4.12,<5",
-  "httpx>=0.28,<1",
   "typing-extensions; python_version<'3.11'",
 ]
 [[project.authors]]
 name = "Trenton H"
 email = "rda0128ou@mozmail.com"
 [project.optional-dependencies]
+httpx = [ "httpx>=0.28,<1" ]
 niquests = [ "niquests>=3,<4" ]
 requests = [ "requests>=2.32,<3" ]
 [project.urls]
@@ -98,6 +98,7 @@ extra-dependencies = [
   "pytest-docker ~= 3.2",
   "pytest-asyncio",
   "pypdf",
+  "httpx>=0.28,<1",
   "niquests>=3.0,<4",
   "requests>=2.32,<3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -384,11 +384,13 @@ name = "tika-client"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
 [package.optional-dependencies]
+httpx = [
+    { name = "httpx" },
+]
 niquests = [
     { name = "niquests" },
 ]
@@ -399,12 +401,12 @@ requests = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.12,<5" },
-    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.28,<1" },
     { name = "niquests", marker = "extra == 'niquests'", specifier = ">=3,<4" },
     { name = "requests", marker = "extra == 'requests'", specifier = ">=2.32,<3" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-provides-extras = ["niquests", "requests"]
+provides-extras = ["httpx", "niquests", "requests"]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## What  

`httpx` is no longer a required dependency. Users must now install at least one HTTP backend via an extra:

  ```console
  pip install "tika-client[httpx]"
  pip install "tika-client[niquests]"
  pip install "tika-client[requests]"
```

  The default backend="auto" is unchanged - it discovers whichever backend is present at runtime, trying httpx first, then niquests, then requests. Users who already have any of the three installed (directly or transitively) are unaffected.

## Why
The pluggable HTTP backend system added in this branch makes pinning a specific library as a hard dependency unnecessary.  Users who prefer niquests or requests should not have httpx forced on them.  Also, given some of the oddness around the potential httpx version 1, this makes it easier for users to switch.  See [this Reddit thread](https://www.reddit.com/r/Python/comments/1rl5kuq/anyone_know_whats_up_with_httpx/) for example.

## Migration

 Anyone running pip install tika-client needs to add a backend extra, e.g. pip install "tika-client[httpx]". No API changes.